### PR TITLE
Block dump endpoint from web scrapers

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+# Block scrapers from scraping our scrapes
+User-agent: *
+Allow: /$
+Disallow: /

--- a/src/layouts/BasePage.astro
+++ b/src/layouts/BasePage.astro
@@ -69,6 +69,7 @@ const themeClass = theme === "light" ? "light" : theme === "dark" ? "dark" : "";
 				<li>
 					<a
 						href="/api/db-dump"
+						rel="nofollow"
 						class="underline transition-colors duration-200 ease rounded hover:bg-base-100 dark:hover:bg-base-800"
 					>
 						Download db dump


### PR DESCRIPTION
- Add rel="nofollow" to db-dump link in footer
- Add robots.txt allowing only landing page, blocking all other paths