### PR TITLE
Fix /api/clip redirect target handling and bump 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "yazzy",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"dependencies": {
 		"@astrojs/node": "9.5.3",
 		"@openrouter/sdk": "^0.8.0",

--- a/src/pages/api/clip.ts
+++ b/src/pages/api/clip.ts
@@ -5,5 +5,5 @@ export const GET: APIRoute = async ({ request }) => {
 	if (!url) {
 		return new Response(`Value '${url}' is not a valid URL`, { status: 400 });
 	}
-	return Response.redirect(new URL(`/${url}`, request.url), 302);
+	return Response.redirect(new URL(`/${url}`));
 };


### PR DESCRIPTION
This branch fixes `/api/clip` to redirect with a direct path target instead of rebuilding an absolute URL from the incoming request, which keeps redirect behavior stable across hosts and proxy setups. It also bumps the app version to `0.2.4`.

Please review the redirect path construction in `src/pages/api/clip.ts` and sanity-check `/api/clip?url=...` for valid and invalid inputs.