### PR TITLE
Fix clip API redirect target construction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "yazzy",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"dependencies": {
 		"@astrojs/node": "9.5.3",
 		"@openrouter/sdk": "^0.8.0",

--- a/src/pages/api/clip.ts
+++ b/src/pages/api/clip.ts
@@ -5,5 +5,5 @@ export const GET: APIRoute = async ({ request }) => {
 	if (!url) {
 		return new Response(`Value '${url}' is not a valid URL`, { status: 400 });
 	}
-	return Response.redirect(new URL(`/${url}`));
+	return Response.redirect(`/${url}`);
 };


### PR DESCRIPTION
## Summary
Build the redirect target as a path string instead of constructing a new URL from an untrusted segment. This avoids runtime URL parsing failures in the clip API route and preserves the intended redirect behavior.

## Review Notes
Please verify `src/pages/api/clip.ts` now redirects correctly for valid `url` query values and still returns `400` when `url` is missing.