### PR TITLE
Upgrade defuddle to 0.15.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@resvg/resvg-js": "^2.6.2",
         "@tailwindcss/vite": "^4.2.1",
         "astro": "^6.0.4",
-        "defuddle": "0.14.0",
+        "defuddle": "0.15.0",
         "dompurify": "^3.3.2",
         "drizzle-orm": "^0.45.1",
         "linkedom": "^0.18.12",
@@ -440,7 +440,7 @@
 
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
-    "defuddle": ["defuddle@0.14.0", "", { "dependencies": { "commander": "^12.1.0" }, "optionalDependencies": { "linkedom": "^0.18.12", "mathml-to-latex": "^1.5.0", "temml": "^0.13.1", "turndown": "^7.2.0" }, "bin": { "defuddle": "dist/cli.js" } }, "sha512-btavZGd1WgiVqrVM62WGRXMUi/aU7ckTZiq0xXWLZMHvzIqNZjwIFQEDRx8MarD7fIgsB90NXZ9xHJkKtapt2Q=="],
+    "defuddle": ["defuddle@0.15.0", "", { "dependencies": { "commander": "^12.1.0" }, "optionalDependencies": { "linkedom": "^0.18.12", "mathml-to-latex": "^1.5.0", "temml": "^0.13.1", "turndown": "^7.2.0" }, "bin": { "defuddle": "dist/cli.js" } }, "sha512-ZIouJe2TcVMZDTpU4G0UBA+kN101dBQ5fxCsamq/zgH4etbRZTd86fcWbYrnus28SFBpMyHWCbL23P1rkp4XUw=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@resvg/resvg-js": "^2.6.2",
         "@tailwindcss/vite": "^4.2.1",
         "astro": "^6.0.4",
-        "defuddle": "^0.13.0",
+        "defuddle": "0.14.0",
         "dompurify": "^3.3.2",
         "drizzle-orm": "^0.45.1",
         "linkedom": "^0.18.12",
@@ -440,7 +440,7 @@
 
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
-    "defuddle": ["defuddle@0.13.0", "", { "dependencies": { "commander": "^12.1.0" }, "optionalDependencies": { "linkedom": "^0.18.12", "mathml-to-latex": "^1.5.0", "temml": "^0.13.1", "turndown": "^7.2.0" }, "bin": { "defuddle": "dist/cli.js" } }, "sha512-GTLNgwt0inWz0rr7lfG4xDeBpY8WiUMPu1F8tSOZZ/My/xmveqUapDy7qanWw4n0BK1NDyQXImtBHNKQ0JYm/w=="],
+    "defuddle": ["defuddle@0.14.0", "", { "dependencies": { "commander": "^12.1.0" }, "optionalDependencies": { "linkedom": "^0.18.12", "mathml-to-latex": "^1.5.0", "temml": "^0.13.1", "turndown": "^7.2.0" }, "bin": { "defuddle": "dist/cli.js" } }, "sha512-btavZGd1WgiVqrVM62WGRXMUi/aU7ckTZiq0xXWLZMHvzIqNZjwIFQEDRx8MarD7fIgsB90NXZ9xHJkKtapt2Q=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "yazzy",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"dependencies": {
 		"@astrojs/node": "^10.0.1",
 		"@openrouter/sdk": "^0.9.11",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"@resvg/resvg-js": "^2.6.2",
 		"@tailwindcss/vite": "^4.2.1",
 		"astro": "^6.0.4",
-		"defuddle": "^0.13.0",
+		"defuddle": "0.14.0",
 		"dompurify": "^3.3.2",
 		"drizzle-orm": "^0.45.1",
 		"linkedom": "^0.18.12",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"@resvg/resvg-js": "^2.6.2",
 		"@tailwindcss/vite": "^4.2.1",
 		"astro": "^6.0.4",
-		"defuddle": "0.14.0",
+		"defuddle": "0.15.0",
 		"dompurify": "^3.3.2",
 		"drizzle-orm": "^0.45.1",
 		"linkedom": "^0.18.12",


### PR DESCRIPTION
## Summary
- upgrade `defuddle` from `0.13.0` to `0.14.0`, then to `0.15.0`, in separate atomic commits
- bump the app patch version to `v0.3.4` after the migration
- validate with `bun run check`, `bun run build`, and browser smoke tests against production and local dev

## Validation
- `bun run check`
- `bun run build`
- `bunx agent-browser --help`
- smoke-tested clipping flow locally with `https://example.com`
- compared production and local clipping output for `https://carter.works/blog/2026-03-31-claude-code-buddies-experiement/`

## Notes
- reviewed `defuddle` `0.14.0` and `0.15.0` release notes with `gh`; neither release called out explicit breaking API changes
- acceptable differences remain between production and local output for the Carter blog post, but the clipping flow works end-to-end